### PR TITLE
Forage add randomized wall density

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,11 +54,8 @@
                 "--eval_env_frameskip=1",
                 "--env=GDY-Forage",
                 "--forage_num_agents=2",
-
-                "--forage_width_min=80",
-                "--forage_width_max=81",
-                "--forage_height_min=80",
-                "--forage_height_max=81",
+                "--forage_width=80",
+                "--forage_height=80",
                 "--forage_energy_per_agent=10",
                 "--forage_wall_density=0.15",
                 "--forage_prediction_error_reward=0",

--- a/envs/args_parsing.py
+++ b/envs/args_parsing.py
@@ -1,0 +1,20 @@
+import argparse
+
+VALUES_RANGE_DELIMITER = ":"
+
+class PossiblyNumericRange2Number(argparse.Action):
+     def __init__(self, str2numeric_cast_fn, *args, **kwargs):
+        """
+            Args:
+                str2numeric_cast_fn - a str2numeric function like int, float
+        """
+        self.str2numeric_cast_fn = str2numeric_cast_fn
+        super().__init__(*args, **kwargs)
+
+     def __call__(self, parser, namespace, values, option_string=None):
+        vals = [self.str2numeric_cast_fn(val) for val in values.split(VALUES_RANGE_DELIMITER)]
+
+        if len(vals) > 2:
+            raise argparse.ArgumentTypeError(f"Input length (after splitting with character {VALUES_RANGE_DELIMITER} must be 1 or 2. Got {len(vals)}")
+        
+        setattr(namespace, self.dest, vals)

--- a/envs/args_parsing.py
+++ b/envs/args_parsing.py
@@ -18,3 +18,4 @@ class PossiblyNumericRange2Number(argparse.Action):
             raise argparse.ArgumentTypeError(f"Input length (after splitting with character {VALUES_RANGE_DELIMITER} must be 1 or 2. Got {len(vals)}")
         
         setattr(namespace, self.dest, vals)
+

--- a/envs/griddly/forage/env.py
+++ b/envs/griddly/forage/env.py
@@ -1,19 +1,40 @@
+from argparse import FileType
 from calendar import c
+from collections.abc import Callable, Iterable, Sequence
 from typing import Optional
 from griddly.gym import GymWrapper
 import numpy as np
 import yaml
 import argparse
+import typing
 
 from envs.predictive_reward_env_wrapper import PredictiveRewardEnvWrapper
+import envs.args_parsing as args_parsing
 
 GYM_ENV_NAME = "GDY-Forage"
+
+def get_value_possibly_from_range(vals: typing.List, range_selection_fn: typing.Callable):
+    """
+        Args: 
+            vals: a list of 1 or 2 values
+            range_selection_fn: a function that selects a value based on a (low, high) range boundaries
+    """
+    if len(vals) == 1:
+        return lambda: vals[0]
+    elif len(vals) == 2:
+        return lambda: range_selection_fn(vals[0], vals[1])
+    else:
+        raise ValueError(f"Length of values list should be at most 2. Got: {len(vals)}")
 
 class ForageEnvFactory:
     def __init__(self, cfg=None):
         self.cfg = cfg
         self.game_config = yaml.safe_load(open("./envs/griddly/forage/forage.yaml"))
         self.num_agents = self.cfg.forage_num_agents
+        
+        self.level_width_sampler = get_value_possibly_from_range(self.cfg.forage_width, np.random.randint)
+        self.level_height_sampler = get_value_possibly_from_range(self.cfg.forage_height, np.random.randint)
+        self.level_wall_density_sampler = get_value_possibly_from_range(self.cfg.forage_wall_density, np.random.uniform)
 
         if self.game_config["Environment"]["Player"]["Count"] != self.num_agents:
             self.game_config["Environment"]["Player"]["Count"] = self.num_agents
@@ -36,8 +57,8 @@ class ForageEnvFactory:
         return "\n".join(["  ".join(row) for row in self._make_level()])
 
     def _make_level(self):
-        width = np.random.randint(self.cfg.forage_width_min, self.cfg.forage_width_max)
-        height = np.random.randint(self.cfg.forage_height_min, self.cfg.forage_height_max)
+        width = self.level_width_sampler()
+        height = self.level_height_sampler()
         energy = self.num_agents * self.cfg.forage_energy_per_agent
 
         # make the bounding box
@@ -65,9 +86,10 @@ class ForageEnvFactory:
                 if level[y][x] == ".":
                     level[y][x] = "e"
                     break
-
+        
         # make obstacles
-        for i in range(int(width*height*self.cfg.forage_wall_density)):
+        print("Width, height, density: ", width, height, wall_density)
+        for i in range(int(width*height*wall_density)):
             x = np.random.randint(1, width-1)
             y = np.random.randint(1, height-1)
             if level[y][x] == ".":
@@ -79,14 +101,25 @@ def add_env_args(parser: argparse.ArgumentParser) -> None:
 
     p.add_argument("--forage_num_agents", default=8, type=int, help="number of agents in the environment")
 
-    p.add_argument("--forage_width_max", default=20, type=int, help="max level width")
-    p.add_argument("--forage_width_min", default=10, type=int, help="min level width")
+    p.add_argument("--forage_width",
+                   default=15,
+                   help='Level width. Can be either a integer value OR a low:high range (e.g., "10:20" to sample from [10, 20) - high excluded)',
+                   action=args_parsing.PossiblyNumericRange2Number,
+                   str2numeric_cast_fn=int)
 
-    p.add_argument("--forage_height_min", default=10, type=int, help="min level height")
-    p.add_argument("--forage_height_max", default=20, type=int, help="max level height")
+    p.add_argument("--forage_height",
+                   default=15,
+                   help='Level height. Can be either a single integer OR a low:high range (e.g., "10:20" to sample from [10, 20) - high excluded)',
+                   action=args_parsing.PossiblyNumericRange2Number,
+                   str2numeric_cast_fn=int)
 
     p.add_argument("--forage_energy_per_agent", default=10, type=int)
-    p.add_argument("--forage_wall_density", default=0.1, type=float)
+
+    p.add_argument("--forage_wall_density",
+                   default=0.05,
+                   help='Level wall density. Can be either a single float OR a low:high range (e.g., "0.2:0.5") from which a value is uniformly drawn',
+                   action=args_parsing.PossiblyNumericRange2Number,
+                   str2numeric_cast_fn=float)
 
     p.add_argument("--forage_max_env_steps", default=1000, type=int)
     p.add_argument("--forage_prediction_error_reward", default=0.00, type=float)

--- a/envs/griddly/forage/env.py
+++ b/envs/griddly/forage/env.py
@@ -88,7 +88,8 @@ class ForageEnvFactory:
                     break
         
         # make obstacles
-        print("Width, height, density: ", width, height, wall_density)
+        wall_density = self.level_wall_density_sampler()
+        
         for i in range(int(width*height*wall_density)):
             x = np.random.randint(1, width-1)
             y = np.random.randint(1, height-1)

--- a/tests/test_griddly_training.py
+++ b/tests/test_griddly_training.py
@@ -39,12 +39,10 @@ class TestGridlyTraining(unittest.TestCase):
         args = [
             "--train_for_env_steps=300000",
             "--forage_num_agents=2",
-            "--forage_width_min=4",
-            "--forage_width_max=5",
-            "--forage_height_min=4",
-            "--forage_height_max=5",
+            "--forage_width=4",
+            "--forage_height=4",
             "--forage_energy_per_agent=1",
-            "--forage_wall_density=0",
+            "--forage_wall_density=0.0",
             "--forage_max_env_steps=2",
             "--forage_prediction_error_reward=0"
         ]
@@ -54,12 +52,10 @@ class TestGridlyTraining(unittest.TestCase):
         args = [
             "--train_for_env_steps=300000",
             "--forage_num_agents=2",
-            "--forage_width_min=4",
-            "--forage_width_max=5",
-            "--forage_height_min=4",
-            "--forage_height_max=5",
+            "--forage_width=4",
+            "--forage_height=4",
             "--forage_energy_per_agent=1",
-            "--forage_wall_density=0",
+            "--forage_wall_density=0.0",
             "--forage_max_env_steps=2",
             "--forage_prediction_error_reward=-0.001"
         ]
@@ -69,12 +65,10 @@ class TestGridlyTraining(unittest.TestCase):
         args = [
             "--train_for_env_steps=80000",
             "--forage_num_agents=2",
-            "--forage_width_min=9",
-            "--forage_width_max=10",
-            "--forage_height_min=9",
-            "--forage_height_max=10",
+            "--forage_width=9",
+            "--forage_height=9",
             "--forage_energy_per_agent=1",
-            "--forage_wall_density=0",
+            "--forage_wall_density=0.0",
             "--forage_max_env_steps=16",
         ]
         self.assertGreater(train_and_eval(args), 0.99)
@@ -83,10 +77,8 @@ class TestGridlyTraining(unittest.TestCase):
         args = [
             "--train_for_env_steps=80000",
             "--forage_num_agents=2",
-            "--forage_width_min=9",
-            "--forage_width_max=10",
-            "--forage_height_min=9",
-            "--forage_height_max=10",
+            "--forage_width=9",
+            "--forage_height=9",
             "--forage_energy_per_agent=1",
             "--forage_wall_density=0.05",
             "--forage_max_env_steps=16",

--- a/tests/test_predictive_forage_env.py
+++ b/tests/test_predictive_forage_env.py
@@ -35,10 +35,5 @@ class TestPredictiveForageEnv(unittest.TestCase):
 
         self.assertGreater(total_rewards, 0.0)
 
-
-import os
-
-os.environ['KMP_DUPLICATE_LIB_OK']='True'
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_predictive_forage_env.py
+++ b/tests/test_predictive_forage_env.py
@@ -9,11 +9,9 @@ class TestPredictiveForageEnv(unittest.TestCase):
         cfg = {
             "forage_num_agents": 3,
             "forage_max_env_steps": 100,
-            "forage_width_min": 9,
-            "forage_width_max": 10,
-            "forage_height_min": 9,
-            "forage_height_max": 10,
-            "forage_wall_density": 0,
+            "forage_width": 9,
+            "forage_height": 9,
+            "forage_wall_density": 0.0,
             "forage_energy_per_agent": 1,
             "forage_prediction_error_reward": 10,
         }
@@ -36,6 +34,11 @@ class TestPredictiveForageEnv(unittest.TestCase):
             total_rewards += sum(rewards)
 
         self.assertGreater(total_rewards, 0.0)
+
+
+import os
+
+os.environ['KMP_DUPLICATE_LIB_OK']='True'
 
 if __name__ == '__main__':
     unittest.main()

--- a/train.sh
+++ b/train.sh
@@ -12,6 +12,7 @@ python -m envs.griddly.train \
     --forage_height_min=10 \
     --forage_height_max=100 \
     --forage_energy_per_agent=1 \
-    --forage_wall_density=0.1 \
+    --forage_wall_density_min=0.1 \
+    --forage_wall_density_max=0.1 \
     --forage_prediction_error_reward=-0.01 \
     "$@"


### PR DESCRIPTION
@daveey I thought about alternatives to having two flags (min and max values), as it's making the testing/running scripts a bit uglier in the common (?) case when we want a constant wall density

However, nothing much more elegant solutions came to mind (all of them required additional flags, which can be confusing).

 Any ideas? We can also keep it as is and improve later if it's required.

Let's squash the commits upon merging